### PR TITLE
Fix for OpenSSH 7.2+

### DIFF
--- a/SshNet/Security/KeyExchangeDiffieHellmanGroupExchangeSha1.cs
+++ b/SshNet/Security/KeyExchangeDiffieHellmanGroupExchangeSha1.cs
@@ -39,7 +39,7 @@ namespace Renci.SshNet.Security
                 HostKey = this._hostKey,
                 MinimumGroupSize = 1024,
                 PreferredGroupSize = 1024,
-                MaximumGroupSize = 1024,
+                MaximumGroupSize = 8192,
                 Prime = this._prime,
                 SubGroup = this._group,
                 ClientExchangeValue = this._clientExchangeValue,
@@ -65,7 +65,7 @@ namespace Renci.SshNet.Security
             this.Session.MessageReceived += Session_MessageReceived;
 
             //  1. send SSH_MSG_KEY_DH_GEX_REQUEST
-            this.SendMessage(new KeyExchangeDhGroupExchangeRequest(1024, 1024, 1024));
+            this.SendMessage(new KeyExchangeDhGroupExchangeRequest(1024, 1024, 8192));
         }
 
         /// <summary>

--- a/SshNet/Security/KeyExchangeDiffieHellmanGroupExchangeSha256.cs
+++ b/SshNet/Security/KeyExchangeDiffieHellmanGroupExchangeSha256.cs
@@ -41,7 +41,7 @@ namespace Renci.SshNet.Security
             this.Session.MessageReceived += Session_MessageReceived;
 
             //  1. send SSH_MSG_KEY_DH_GEX_REQUEST
-            this.SendMessage(new KeyExchangeDhGroupExchangeRequest(1024,1024,1024));
+            this.SendMessage(new KeyExchangeDhGroupExchangeRequest(2048, 2048, 2048));
             
         }
 
@@ -70,9 +70,9 @@ namespace Renci.SshNet.Security
                 ClientPayload = this._clientPayload,
                 ServerPayload = this._serverPayload,
                 HostKey = this._hostKey,
-                MinimumGroupSize = 1024,
-                PreferredGroupSize = 1024,
-                MaximumGroupSize = 1024,
+                MinimumGroupSize = 2048,
+                PreferredGroupSize = 2048,
+                MaximumGroupSize = 2048,
                 Prime = this._prime,
                 SubGroup = this._group,
                 ClientExchangeValue = this._clientExchangeValue,

--- a/SshNet/Security/KeyExchangeDiffieHellmanGroupExchangeSha256.cs
+++ b/SshNet/Security/KeyExchangeDiffieHellmanGroupExchangeSha256.cs
@@ -41,7 +41,7 @@ namespace Renci.SshNet.Security
             this.Session.MessageReceived += Session_MessageReceived;
 
             //  1. send SSH_MSG_KEY_DH_GEX_REQUEST
-            this.SendMessage(new KeyExchangeDhGroupExchangeRequest(2048, 2048, 2048));
+            this.SendMessage(new KeyExchangeDhGroupExchangeRequest(1024, 1024, 8192));
             
         }
 
@@ -70,9 +70,9 @@ namespace Renci.SshNet.Security
                 ClientPayload = this._clientPayload,
                 ServerPayload = this._serverPayload,
                 HostKey = this._hostKey,
-                MinimumGroupSize = 2048,
-                PreferredGroupSize = 2048,
-                MaximumGroupSize = 2048,
+                MinimumGroupSize = 1024,
+                PreferredGroupSize = 1024,
+                MaximumGroupSize = 8192,
                 Prime = this._prime,
                 SubGroup = this._group,
                 ClientExchangeValue = this._clientExchangeValue,


### PR DESCRIPTION
This and allows the app to connect to OpenSSH 7.2+ servers, where the supported Diffie-Hellman group key exchange group sizes were incompatible with what the app offered.
Fix for #3.